### PR TITLE
improve log ergonomics and adapters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,93 @@
+# AGENTS.md
+
+This repository is a Go utility library module: `github.com/pubgo/funk/v2`.
+
+## What this repo contains
+
+- Many small, reusable Go packages under the repository root.
+- Core modules are documented in their own READMEs:
+  - [root overview](./README.md)
+  - [design](./docs/DESIGN.md)
+  - [errors](./errors/README.md)
+  - [result](./result/README.md)
+  - [config](./config/README.md)
+  - [features](./features/README.md)
+  - [log](./log/README.md)
+  - [env](./env/README.md)
+  - [stack](./stack/README.md)
+  - [connmux](./connmux/README.md)
+
+## Working rules for AI coding agents
+
+1. Always run Go commands from the repository root: `/Users/barry/git/funk`.
+2. Preserve the module import path suffix `/v2` when adding or editing imports.
+3. Prefer the smallest possible change; do not reformat unrelated packages.
+4. Before editing a package, read that package README first if it exists.
+5. For package-local changes, prefer targeted tests before running wider suites.
+6. After changing exported behavior, update the nearest README or package docs.
+7. Treat logger/context field maps as immutable data; avoid mutating reused state in place.
+8. Prefer existing helpers from `errors`, `result`, `log`, `config`, and `features` over introducing duplicate patterns.
+9. Keep generated/proto-related changes scoped; do not edit generated output casually.
+10. If a change touches shared APIs, search for cross-package usages before refactoring.
+
+## Common commands
+
+Run from repo root:
+
+- Full test + race + coverage profile via Makefile: `make test`
+- Coverage HTML: `make test_html`
+- Benchmarks (root package target from Makefile): `make test_bench`
+- All-package vet: `make vet`
+- Lint: `make lint`
+- Format/refactor: `make refactor`
+- All-package Go tests directly: `go test ./...`
+- Package-scoped tests: `go test ./log`, `go test ./errors`, etc.
+
+## Protobuf / code generation
+
+Proto generation is configured in [protobuf.yaml](./protobuf.yaml).
+
+Relevant commands:
+
+- `make protobuf`
+- `make protolint`
+
+Notes:
+
+- Generated output goes to `./proto`
+- Vendored proto dependencies live in `./proto-vendor`
+- Custom plugins live under `./cmds/`
+
+## Repository map
+
+- `errors/`: enriched error model, wrapping, tags, stack-aware debugging
+- `result/`: generic `Result[T]` / `Error` flow helpers and async helpers
+- `log/`: zerolog-based structured logging facade, context-aware fields, slog/std adapters
+- `config/`: YAML config loading, env substitution, merge/patch support, expression helpers
+- `features/`: typed feature flags, env + CLI integration
+- `env/`: environment variable helpers and `.env` support
+- `stack/`: caller and stack-trace helpers
+- `async/`: future/promise/iterator helpers
+- `component/`: integrations/adapters (bbolt, gorm, nats, cloudevent, etc.)
+- `cmds/`: codegen and upgrade tools
+- `docs/`: high-level design docs
+
+## Testing guidance
+
+- Start with the most local package affected.
+- Prefer focused regression tests for bug fixes.
+- If changing behavior in foundational packages like `errors`, `result`, `log`, or `config`, run at least that package and nearby dependents.
+- For performance-sensitive changes, add or run benchmarks near the edited package when practical.
+
+## Known repo conventions
+
+- Package docs often live in `_doc.go`, `_docs.go`, `README.md`, and `README.zh.md`.
+- Many packages are intentionally lightweight facades over existing libraries; preserve that style.
+- The logging package intentionally depends on `zerolog`; do not abstract it away unless explicitly requested.
+- Configuration and feature helpers favor typed APIs and declarative usage over ad-hoc maps.
+
+## When in doubt
+
+- Prefer linking to existing docs instead of copying them into new files.
+- Follow the style and naming already present in the touched package.
+- If a Make target and real package layout disagree, trust the current package structure and verify with `go test` / `go vet`.

--- a/log/README.md
+++ b/log/README.md
@@ -11,6 +11,25 @@ The logging module provides a high-performance, structured logging system based 
 - **Modular Loggers**: Namespaced loggers for different components
 - **Multiple Output Formats**: Console and JSON output formats
 
+## Design Notes
+
+- The package intentionally uses `zerolog` as its concrete backend and exposes `Event` as an alias of `zerolog.Event` for a fluent, low-overhead API.
+- `Logger.WithFields(...)` returns a derived logger and does not mutate the original logger.
+- `WithLogger(ctx, ...)` is the convenience entry point for attaching a logger to a context.
+- `WithFields(ctx, ...)` is the convenience entry point for attaching request-scoped fields to a context.
+- `CreateFieldsCtx(...)` snapshots the initial field map so later mutations to the caller's map do not leak into logging context.
+- `WithLogger(...)`, `WithFields(...)`, `GetFieldsFromCtx(...)`, and `WithDisabled(...)` are nil-safe helpers for request-scoped logging flows.
+- Global helpers such as `log.Info(ctx)` and `log.Err(err, ctx)` honor the logger stored in the context.
+- `FromCtx(ctx)` is the ergonomic way to fetch the effective logger from a context when you need to keep chaining logger methods.
+- `UpdateFieldsCtx(...)` returns a new context and does not mutate field maps already stored in parent contexts.
+- When logger fields and context fields use the same key, **context fields win**. This lets request-scoped metadata override module defaults safely.
+
+## Recommended Patterns
+
+- **Typical request flow**: use `WithLogger` + `WithFields`, then call `log.Info(ctx)` / `log.Err(err, ctx)`.
+- **Need direct logger chaining from context**: use `log.FromCtx(ctx)`.
+- **Low-level explicit construction**: keep `CreateCtx` / `CreateFieldsCtx` for places where you want stricter, non-helper semantics.
+
 ## Installation
 
 ```bash
@@ -60,6 +79,7 @@ import (
 
 // Create a context with fields
 ctx := context.Background()
+ctx = log.WithLogger(ctx, log.GetLogger("request"))
 ctx = log.WithFields(ctx, map[string]any{
     "request_id": "abc123",
     "user_id": 42,
@@ -67,7 +87,20 @@ ctx = log.WithFields(ctx, map[string]any{
 
 // Log with context (fields are automatically included)
 log.Info(ctx).Msg("Processing request")
+
+// Global helpers also use the context-bound logger automatically.
+
+// If you need logger chaining, fetch the effective logger from context.
+log.FromCtx(ctx).WithName("db").Info(ctx).Msg("Query finished")
 ```
+
+### Context Helper Cheat Sheet
+
+- `WithLogger`: bind a request-scoped logger to context
+- `WithFields`: append request-scoped fields
+- `log.Info(ctx)` / `log.Err(err, ctx)`: the common path for emitting logs
+- `FromCtx`: fetch the effective logger when you need more chaining
+- `CreateCtx` / `CreateFieldsCtx`: lower-level explicit constructors
 
 ## Core Concepts
 
@@ -176,6 +209,29 @@ err := errors.New("database connection failed", errors.Tags{
 log.Err(err).Msg("Connection attempt failed")
 ```
 
+### Slog / Std Adapter Usage
+
+```go
+import (
+    "log/slog"
+    "github.com/pubgo/funk/v2/log"
+)
+
+ctx := log.WithLogger(nil, log.GetLogger("request"))
+
+// slog adapter
+slogger := slog.New(log.NewSlog(log.FromCtx(ctx)))
+slogger.Info("handled request")
+
+// std-style adapter
+std := log.NewStd(log.FromCtx(ctx))
+std.Println("request", "finished")
+```
+
+Notes:
+- `NewSlog(nil)` and `NewStd(nil)` safely fall back to the global logger.
+- `StdLogger.Println(...)` follows standard-library-style spacing between arguments.
+
 ### Event Building
 
 ```go
@@ -193,33 +249,41 @@ log.Info().
 
 ### Core Functions
 
-| Function | Description |
-|----------|-------------|
-| `GetLogger(names ...string)` | Get a module-specific logger |
-| `SetLogger(log *zerolog.Logger)` | Set the global logger |
-| `WithFields(ctx context.Context, fields Fields)` | Add fields to context |
-| `GetFieldsFromCtx(ctx context.Context)` | Extract fields from context |
+| Function                                              | Description                                    |
+| ----------------------------------------------------- | ---------------------------------------------- |
+| `FromCtx(ctx context.Context)`                        | Get the effective logger from context          |
+| `GetFromCtx(ctx context.Context, loggers ...Logger)`  | Low-level logger lookup with optional fallback |
+| `GetLogger(names ...string)`                          | Get a module-specific logger                   |
+| `SetLogger(log *zerolog.Logger)`                      | Set the global logger                          |
+| `CreateCtx(ctx context.Context, ll Logger)`           | Create a context with an explicit logger       |
+| `WithLogger(ctx context.Context, ll Logger)`          | Attach a logger to context                     |
+| `WithFields(ctx context.Context, fields Fields)`      | Add fields to context                          |
+| `CreateFieldsCtx(ctx context.Context, evt Fields)`    | Create a context with initial fields           |
+| `UpdateFieldsCtx(ctx context.Context, fields Fields)` | Add or override fields in a derived context    |
+| `GetFieldsFromCtx(ctx context.Context)`               | Extract fields from context                    |
 
 ### Logging Functions
 
-| Function | Description |
-|----------|-------------|
-| `Debug(ctx ...context.Context)` | Start a debug level log event |
-| `Info(ctx ...context.Context)` | Start an info level log event |
-| `Warn(ctx ...context.Context)` | Start a warning level log event |
-| `Error(ctx ...context.Context)` | Start an error level log event |
+| Function                                 | Description                                |
+| ---------------------------------------- | ------------------------------------------ |
+| `Debug(ctx ...context.Context)`          | Start a debug level log event              |
+| `Info(ctx ...context.Context)`           | Start an info level log event              |
+| `Warn(ctx ...context.Context)`           | Start a warning level log event            |
+| `Error(ctx ...context.Context)`          | Start an error level log event             |
 | `Err(err error, ctx ...context.Context)` | Start an error log event with error detail |
-| `Fatal(ctx ...context.Context)` | Start a fatal log event |
-| `Panic(ctx ...context.Context)` | Start a panic log event |
+| `Fatal(ctx ...context.Context)`          | Start a fatal log event                    |
+| `Panic(ctx ...context.Context)`          | Start a panic log event                    |
 
 ### Utility Functions
 
-| Function | Description |
-|----------|-------------|
-| `NewEvent()` | Create a new dictionary event |
-| `RecordErr(logs ...Logger)` | Create an error recording function |
-| `Output(w io.Writer)` | Create logger with custom output |
-| `OutputWriter(w func([]byte) (int, error))` | Create logger with custom writer function |
+| Function                                    | Description                                    |
+| ------------------------------------------- | ---------------------------------------------- |
+| `NewEvent()`                                | Create a new dictionary event                  |
+| `RecordErr(logs ...Logger)`                 | Create an error recording function             |
+| `Output(w io.Writer)`                       | Create logger with custom output               |
+| `OutputWriter(w func([]byte) (int, error))` | Create logger with custom writer function      |
+| `NewSlog(log Logger)`                       | Create a `slog.Handler` backed by `log.Logger` |
+| `NewStd(log Logger)`                        | Create a std-style logger adapter              |
 
 ## Best Practices
 
@@ -229,6 +293,14 @@ log.Info().
 4. **Appropriate Levels**: Use appropriate log levels for different scenarios
 5. **Avoid Sensitive Data**: Never log passwords, tokens, or other sensitive information
 6. **Error Detail**: Always log errors with sufficient context for debugging
+7. **Treat Loggers as Immutable**: Chain `WithName` / `WithFields` to create derived loggers instead of expecting in-place mutation
+8. **Prefer Context For Request Data**: Put request-specific values in `context.Context` rather than module logger defaults
+
+## Performance Notes
+
+- The package keeps `zerolog` as the execution engine to preserve its allocation profile and fluent builder API.
+- Recent regression tests ensure context-field merging does not leak state into reusable loggers.
+- Benchmarks are included in `z_bench_test.go` for context merging and context-aware info logging so future changes can be measured quickly.
 
 ## Integration Patterns
 
@@ -286,12 +358,16 @@ import (
 func handleRequest(ctx context.Context) {
     // Add request ID to context
     requestID := uuid.New().String()
+    ctx = log.WithLogger(ctx, log.GetLogger("request"))
     ctx = log.WithFields(ctx, map[string]any{
         "request_id": requestID,
     })
     
     // Log with request context
     log.Info(ctx).Msg("Handling request")
+
+    // Continue chaining on the effective context logger when needed.
+    log.FromCtx(ctx).WithName("downstream").Info(ctx).Msg("Calling processData")
     
     // Pass context to downstream functions
     processData(ctx)

--- a/log/README.zh.md
+++ b/log/README.zh.md
@@ -11,6 +11,25 @@
 - **模块化日志记录器**: 带命名空间的不同组件日志记录器
 - **多种输出格式**: 控制台和JSON输出格式
 
+## 设计说明
+
+- 该包当前**有意**使用 `zerolog` 作为具体后端，并通过 `Event` 别名暴露 `zerolog.Event`，以保留低开销和流式链式 API。
+- `Logger.WithFields(...)` 会返回一个派生 logger，不会修改原 logger。
+- `WithLogger(ctx, ...)` 是给 `context.Context` 绑定 logger 的便捷入口。
+- `WithFields(ctx, ...)` 是给 `context.Context` 添加请求级字段的便捷入口。
+- `CreateFieldsCtx(...)` 会对初始字段 map 做一次快照，避免调用方后续修改原 map 时污染日志上下文。
+- `WithLogger(...)`、`WithFields(...)`、`GetFieldsFromCtx(...)` 和 `WithDisabled(...)` 都是 nil-safe 的辅助函数，适合请求级日志链路使用。
+- `log.Info(ctx)`、`log.Err(err, ctx)` 这类全局 helper 会自动尊重 context 中绑定的 logger。
+- `FromCtx(ctx)` 是从 context 中取出“实际生效 logger”的更顺手入口，适合继续链式调用。
+- `UpdateFieldsCtx(...)` 会返回一个新的 context，不会修改父 context 中已有的字段 map。
+- 当 logger 默认字段与 context 字段同名时，**context 字段优先**，这样请求级元数据可以安全覆盖模块默认值。
+
+## 推荐用法
+
+- **常规请求链路**：优先使用 `WithLogger` + `WithFields`，然后直接调用 `log.Info(ctx)` / `log.Err(err, ctx)`。
+- **需要继续链式操作 logger**：使用 `log.FromCtx(ctx)`。
+- **底层显式构造场景**：保留 `CreateCtx` / `CreateFieldsCtx`，用于更严格、非 helper 风格的用法。
+
 ## 安装
 
 ```bash
@@ -60,6 +79,7 @@ import (
 
 // 创建带字段的上下文
 ctx := context.Background()
+ctx = log.WithLogger(ctx, log.GetLogger("request"))
 ctx = log.WithFields(ctx, map[string]any{
     "request_id": "abc123",
     "user_id": 42,
@@ -67,7 +87,20 @@ ctx = log.WithFields(ctx, map[string]any{
 
 // 带上下文的日志记录（字段自动包含）
 log.Info(ctx).Msg("处理请求")
+
+// 全局 helper 也会自动使用 context 里绑定的 logger。
+
+// 如果还需要继续链式调用 logger，可从 context 中取出实际生效 logger。
+log.FromCtx(ctx).WithName("db").Info(ctx).Msg("查询完成")
 ```
+
+### Context Helper 速查
+
+- `WithLogger`：给 context 绑定请求级 logger
+- `WithFields`：追加请求级字段
+- `log.Info(ctx)` / `log.Err(err, ctx)`：最常用的日志输出路径
+- `FromCtx`：当你还需要继续链式调用 logger 时使用
+- `CreateCtx` / `CreateFieldsCtx`：更底层、显式的构造入口
 
 ## 核心概念
 
@@ -176,6 +209,30 @@ err := errors.New("数据库连接失败", errors.Tags{
 log.Err(err).Msg("连接尝试失败")
 ```
 
+### Slog / Std 适配器用法
+
+```go
+import (
+    "log/slog"
+    "github.com/pubgo/funk/v2/log"
+)
+
+ctx := log.WithLogger(nil, log.GetLogger("request"))
+
+// slog 适配器
+slogger := slog.New(log.NewSlog(log.FromCtx(ctx)))
+slogger.Info("handled request")
+
+// std 风格适配器
+std := log.NewStd(log.FromCtx(ctx))
+std.Println("request", "finished")
+```
+
+说明：
+
+- `NewSlog(nil)` 和 `NewStd(nil)` 都会安全回退到全局 logger。
+- `StdLogger.Println(...)` 现在会像标准库一样，在参数之间插入空格。
+
 ### 事件构建
 
 ```go
@@ -193,33 +250,41 @@ log.Info().
 
 ### 核心函数
 
-| 函数 | 描述 |
-|------|------|
-| `GetLogger(names ...string)` | 获取模块特定日志记录器 |
-| `SetLogger(log *zerolog.Logger)` | 设置全局日志记录器 |
-| `WithFields(ctx context.Context, fields Fields)` | 向上下文添加字段 |
-| `GetFieldsFromCtx(ctx context.Context)` | 从上下文提取字段 |
+| 函数                                                  | 描述                                  |
+| ----------------------------------------------------- | ------------------------------------- |
+| `FromCtx(ctx context.Context)`                        | 获取 context 中实际生效的 logger      |
+| `GetFromCtx(ctx context.Context, loggers ...Logger)`  | 底层 logger 查找入口，可传备用 logger |
+| `GetLogger(names ...string)`                          | 获取模块特定日志记录器                |
+| `SetLogger(log *zerolog.Logger)`                      | 设置全局日志记录器                    |
+| `CreateCtx(ctx context.Context, ll Logger)`           | 创建带显式 logger 的上下文            |
+| `WithLogger(ctx context.Context, ll Logger)`          | 给上下文绑定 logger                   |
+| `WithFields(ctx context.Context, fields Fields)`      | 向上下文添加字段                      |
+| `CreateFieldsCtx(ctx context.Context, evt Fields)`    | 创建带初始字段的上下文                |
+| `UpdateFieldsCtx(ctx context.Context, fields Fields)` | 在派生 context 中新增或覆盖字段       |
+| `GetFieldsFromCtx(ctx context.Context)`               | 从上下文提取字段                      |
 
 ### 日志函数
 
-| 函数 | 描述 |
-|------|------|
-| `Debug(ctx ...context.Context)` | 开始调试级别日志事件 |
-| `Info(ctx ...context.Context)` | 开始信息级别日志事件 |
-| `Warn(ctx ...context.Context)` | 开始警告级别日志事件 |
-| `Error(ctx ...context.Context)` | 开始错误级别日志事件 |
+| 函数                                     | 描述                             |
+| ---------------------------------------- | -------------------------------- |
+| `Debug(ctx ...context.Context)`          | 开始调试级别日志事件             |
+| `Info(ctx ...context.Context)`           | 开始信息级别日志事件             |
+| `Warn(ctx ...context.Context)`           | 开始警告级别日志事件             |
+| `Error(ctx ...context.Context)`          | 开始错误级别日志事件             |
 | `Err(err error, ctx ...context.Context)` | 开始带错误详细信息的错误日志事件 |
-| `Fatal(ctx ...context.Context)` | 开始致命日志事件 |
-| `Panic(ctx ...context.Context)` | 开始恐慌日志事件 |
+| `Fatal(ctx ...context.Context)`          | 开始致命日志事件                 |
+| `Panic(ctx ...context.Context)`          | 开始恐慌日志事件                 |
 
 ### 实用函数
 
-| 函数 | 描述 |
-|------|------|
-| `NewEvent()` | 创建新字典事件 |
-| `RecordErr(logs ...Logger)` | 创建错误记录函数 |
-| `Output(w io.Writer)` | 创建带自定义输出的日志记录器 |
-| `OutputWriter(w func([]byte) (int, error))` | 创建带自定义写入函数的日志记录器 |
+| 函数                                        | 描述                                    |
+| ------------------------------------------- | --------------------------------------- |
+| `NewEvent()`                                | 创建新字典事件                          |
+| `RecordErr(logs ...Logger)`                 | 创建错误记录函数                        |
+| `Output(w io.Writer)`                       | 创建带自定义输出的日志记录器            |
+| `OutputWriter(w func([]byte) (int, error))` | 创建带自定义写入函数的日志记录器        |
+| `NewSlog(log Logger)`                       | 创建基于 `log.Logger` 的 `slog.Handler` |
+| `NewStd(log Logger)`                        | 创建 std 风格 logger 适配器             |
 
 ## 最佳实践
 
@@ -229,6 +294,14 @@ log.Info().
 4. **适当级别**: 为不同场景使用适当的日志级别
 5. **避免敏感数据**: 永远不要记录密码、令牌或其他敏感信息
 6. **错误详细信息**: 始终记录带足够上下文的错误以便调试
+7. **把 Logger 当成不可变对象**: 通过 `WithName` / `WithFields` 链式派生新 logger，而不是依赖原地修改
+8. **请求数据优先放进 Context**: 请求级字段放入 `context.Context`，模块级默认字段放在 logger 上
+
+## 性能说明
+
+- 该模块保留 `zerolog` 作为执行引擎，以维持它的低分配特性和顺滑的 builder 体验。
+- 新增回归测试确保 context 字段合并不会污染可复用 logger 的内部状态。
+- `z_bench_test.go` 中提供了 context 合并和 context-aware info logging 的 benchmark，便于后续改动快速比对性能。
 
 ## 集成模式
 
@@ -286,12 +359,16 @@ import (
 func handleRequest(ctx context.Context) {
     // 向上下文添加请求ID
     requestID := uuid.New().String()
+    ctx = log.WithLogger(ctx, log.GetLogger("request"))
     ctx = log.WithFields(ctx, map[string]any{
         "request_id": requestID,
     })
     
     // 带请求上下文的日志记录
     log.Info(ctx).Msg("处理请求")
+
+    // 需要继续链式调用 logger 时，可从 context 中取出实际生效 logger。
+    log.FromCtx(ctx).WithName("downstream").Info(ctx).Msg("调用 processData")
     
     // 将上下文传递给下游函数
     processData(ctx)

--- a/log/context.go
+++ b/log/context.go
@@ -13,6 +13,12 @@ type (
 	ctxMapFieldKey struct{}
 )
 
+// FromCtx returns the logger stored in the context or the global logger when
+// the context does not carry one.
+func FromCtx(ctx context.Context) Logger {
+	return GetFromCtx(ctx)
+}
+
 func GetFromCtx(ctx context.Context, loggers ...Logger) Logger {
 	defaultLog := stdLog
 	if len(loggers) > 0 {
@@ -38,12 +44,33 @@ func CreateCtx(ctx context.Context, ll Logger) context.Context {
 	return context.WithValue(ctx, ctxLoggerKey{}, ll)
 }
 
+// WithLogger attaches a logger to the context and is safe to use with nil input.
+// When ctx is nil it falls back to context.Background(); when ll is nil it falls
+// back to the global logger.
+func WithLogger(ctx context.Context, ll Logger) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if ll == nil {
+		ll = stdLog
+	}
+
+	return context.WithValue(ctx, ctxLoggerKey{}, ll)
+}
+
 func CreateFieldsCtx(ctx context.Context, evt Fields) context.Context {
 	if evt == nil || ctx == nil {
 		log.Panicln("ctx or log event is nil")
 	}
 
-	return context.WithValue(ctx, ctxEventKey{}, evt)
+	return context.WithValue(ctx, ctxEventKey{}, maps.Clone(evt))
+}
+
+// WithFields adds or overrides fields in the context used by log events.
+// It is a nil-safe convenience wrapper around UpdateFieldsCtx.
+func WithFields(ctx context.Context, fields Fields) context.Context {
+	return UpdateFieldsCtx(ctx, fields)
 }
 
 func UpdateFieldsCtx(ctx context.Context, fields Fields) context.Context {
@@ -55,9 +82,9 @@ func UpdateFieldsCtx(ctx context.Context, fields Fields) context.Context {
 		return ctx
 	}
 
-	evt := make(Fields)
-	if e := GetFieldsFromCtx(ctx); e != nil {
-		evt = e
+	evt := maps.Clone(GetFieldsFromCtx(ctx))
+	if evt == nil {
+		evt = make(Fields, len(fields))
 	}
 
 	maps.Copy(evt, fields)
@@ -65,6 +92,10 @@ func UpdateFieldsCtx(ctx context.Context, fields Fields) context.Context {
 }
 
 func GetFieldsFromCtx(ctx context.Context) Fields {
+	if ctx == nil {
+		return nil
+	}
+
 	evt, ok := ctx.Value(ctxEventKey{}).(Fields)
 	if ok {
 		return evt
@@ -81,6 +112,10 @@ func WithDisabled(ctx context.Context) context.Context {
 }
 
 func isLogDisabled(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+
 	b, ok := ctx.Value(disableLogKey{}).(bool)
 	return b && ok
 }

--- a/log/global.go
+++ b/log/global.go
@@ -93,10 +93,6 @@ func SetLogger(log *zerolog.Logger) {
 }
 
 func SetEnableChecker(checker EnableChecker) {
-	if checker == nil {
-		return
-	}
-
 	logEnableChecker = checker
 }
 
@@ -105,35 +101,35 @@ func SetEnableChecker(checker EnableChecker) {
 //
 // You must call msg on the returned event in order to send the event.
 func Err(err error, ctx ...context.Context) *zerolog.Event {
-	return stdLog.Err(err, ctx...)
+	return getLoggerFromArgs(ctx...).Err(err, ctx...)
 }
 
 // Debug starts a new message with debug level.
 //
 // You must call msg on the returned event in order to send the event.
 func Debug(ctx ...context.Context) *zerolog.Event {
-	return stdLog.Debug(ctx...)
+	return getLoggerFromArgs(ctx...).Debug(ctx...)
 }
 
 // Info starts a new message with info level.
 //
 // You must call msg on the returned event in order to send the event.
 func Info(ctx ...context.Context) *zerolog.Event {
-	return stdLog.Info(ctx...)
+	return getLoggerFromArgs(ctx...).Info(ctx...)
 }
 
 // Warn starts a new message with warn level.
 //
 // You must call msg on the returned event in order to send the event.
 func Warn(ctx ...context.Context) *zerolog.Event {
-	return stdLog.Warn(ctx...)
+	return getLoggerFromArgs(ctx...).Warn(ctx...)
 }
 
 // Error starts a new message with error level.
 //
 // You must call msg on the returned event in order to send the event.
 func Error(ctx ...context.Context) *zerolog.Event {
-	return stdLog.Error(ctx...)
+	return getLoggerFromArgs(ctx...).Error(ctx...)
 }
 
 // Fatal starts a new message with fatal level. The os.Exit(1) function
@@ -141,7 +137,7 @@ func Error(ctx ...context.Context) *zerolog.Event {
 //
 // You must call msg on the returned event in order to send the event.
 func Fatal(ctx ...context.Context) *zerolog.Event {
-	return stdLog.Fatal(ctx...)
+	return getLoggerFromArgs(ctx...).Fatal(ctx...)
 }
 
 // Panic starts a new message with panic level. The message is also sent
@@ -149,7 +145,7 @@ func Fatal(ctx ...context.Context) *zerolog.Event {
 //
 // You must call msg on the returned event in order to send the event.
 func Panic(ctx ...context.Context) *zerolog.Event {
-	return stdLog.Panic(ctx...)
+	return getLoggerFromArgs(ctx...).Panic(ctx...)
 }
 
 // Print sends a log event using debug level and no extra field.
@@ -176,4 +172,14 @@ func (w writerFunc) Write(p []byte) (n int, err error) {
 
 func OutputWriter(w func(p []byte) (n int, err error)) Logger {
 	return New(lo.ToPtr(stdZeroLog.Output(writerFunc(w))))
+}
+
+func getLoggerFromArgs(ctxL ...context.Context) Logger {
+	for i := range ctxL {
+		if ctxL[i] != nil {
+			return GetFromCtx(ctxL[i])
+		}
+	}
+
+	return stdLog
 }

--- a/log/impl.log.go
+++ b/log/impl.log.go
@@ -76,11 +76,11 @@ func (l *loggerImpl) WithFields(m Fields) Logger {
 
 	log := l.copy()
 	logFields := make(Fields, len(m)+len(log.fields))
-	for k, v := range m {
+	for k, v := range log.fields {
 		logFields[k] = v
 	}
 
-	for k, v := range log.fields {
+	for k, v := range m {
 		logFields[k] = v
 	}
 
@@ -215,12 +215,23 @@ func (l *loggerImpl) newEvent(ctx context.Context, e *zerolog.Event) *zerolog.Ev
 		e = e.CallerSkipFrame(l.callerSkip)
 	}
 
-	if fields == nil {
-		fields = GetFieldsFromCtx(ctx)
-	} else {
-		for k, v := range GetFieldsFromCtx(ctx) {
-			fields[k] = v
+	ctxFields := GetFieldsFromCtx(ctx)
+	switch {
+	case len(fields) == 0 && len(ctxFields) == 0:
+		fields = nil
+	case len(ctxFields) == 0:
+		fields = maps.Clone(fields)
+	case len(fields) == 0:
+		fields = maps.Clone(ctxFields)
+	default:
+		mergedFields := make(Fields, len(fields)+len(ctxFields))
+		for k, v := range fields {
+			mergedFields[k] = v
 		}
+		for k, v := range ctxFields {
+			mergedFields[k] = v
+		}
+		fields = mergedFields
 	}
 
 	if len(fields) > 0 {

--- a/log/impl.slog.go
+++ b/log/impl.slog.go
@@ -11,6 +11,10 @@ import (
 )
 
 func NewSlog(log Logger) slog.Handler {
+	if log == nil {
+		log = stdLog
+	}
+
 	return &slogImpl{l: log.WithCallerSkip(3)}
 }
 
@@ -41,7 +45,17 @@ type slogImpl struct {
 }
 
 func (s slogImpl) Enabled(ctx context.Context, level slog.Level) bool {
-	return s.l.(*loggerImpl).enabled(ctx, logLevels[convertSlog(level)])
+	if isLogDisabled(ctx) {
+		return false
+	}
+
+	if enabler, ok := s.l.(interface {
+		enabled(context.Context, zerolog.Level) bool
+	}); ok {
+		return enabler.enabled(ctx, logLevels[convertSlog(level)])
+	}
+
+	return logLevels[convertSlog(level)] >= zerolog.GlobalLevel()
 }
 
 func (s slogImpl) Handle(ctx context.Context, r slog.Record) error {

--- a/log/impl.std.go
+++ b/log/impl.std.go
@@ -1,10 +1,17 @@
 package log
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 var _ StdLogger = (*stdLogImpl)(nil)
 
 func NewStd(log Logger) StdLogger {
+	if log == nil {
+		log = stdLog
+	}
+
 	return &stdLogImpl{log: log.WithCallerSkip(1)}
 }
 
@@ -29,5 +36,5 @@ func (s *stdLogImpl) Logf(format string, v ...any) {
 }
 
 func (s *stdLogImpl) Println(v ...any) {
-	s.log.Info().Msg(fmt.Sprint(v...))
+	s.log.Info().Msg(strings.TrimSuffix(fmt.Sprintln(v...), "\n"))
 }

--- a/log/util.go
+++ b/log/util.go
@@ -27,6 +27,10 @@ func errDetail(err error) string {
 
 func RecordErr(logs ...Logger) func(ctx context.Context, err error) error {
 	return func(ctx context.Context, err error) error {
+		if err == nil {
+			return nil
+		}
+
 		ctx = lo.If(ctx != nil, ctx).ElseF(context.Background)
 
 		logger := stdLog
@@ -88,43 +92,4 @@ func GetEventBuf(evt *Event) []byte {
 	}
 
 	return append(convertEvent(evt).buf, '}')
-}
-
-func mergeEvent(target *Event, from ...*Event) *Event {
-	if len(from) == 0 {
-		return target
-	}
-
-	if target == nil {
-		target = zerolog.Dict()
-	}
-
-	targetEvent := convertEvent(target)
-	targetEvent.buf = bytes.TrimSpace(bytes.Trim(targetEvent.buf, ","))
-	for i := range from {
-		if from[i] == nil {
-			continue
-		}
-
-		buf := slices.Clone(convertEvent(from[i]).buf)
-		if len(buf) == 0 {
-			continue
-		}
-
-		buf = bytes.TrimLeft(buf, "{")
-		buf = bytes.TrimSpace(bytes.Trim(buf, ","))
-		if len(buf) == 0 {
-			continue
-		}
-
-		if len(targetEvent.buf) == 0 {
-			targetEvent.buf = append(targetEvent.buf, '{')
-			targetEvent.buf = append(targetEvent.buf, buf...)
-		} else {
-			targetEvent.buf = append(targetEvent.buf, ","...)
-			targetEvent.buf = append(targetEvent.buf, buf...)
-		}
-	}
-	targetEvent.buf = bytes.TrimSpace(targetEvent.buf)
-	return target
 }

--- a/log/z_bench_test.go
+++ b/log/z_bench_test.go
@@ -1,0 +1,30 @@
+package log_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/pubgo/funk/v2/log"
+)
+
+func BenchmarkInfoWithContext(b *testing.B) {
+	logger := log.Output(io.Discard).WithFields(log.Fields{"component": "bench", "scope": "logger"})
+	ctx := log.CreateFieldsCtx(context.Background(), log.Fields{"scope": "ctx", "request_id": "req-bench"})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Info(ctx).Str("iteration", "bench").Msg("benchmark")
+	}
+}
+
+func BenchmarkUpdateFieldsCtx(b *testing.B) {
+	ctx := log.CreateFieldsCtx(context.Background(), log.Fields{"request_id": "req-bench", "trace_id": "trace-bench"})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = log.UpdateFieldsCtx(ctx, log.Fields{"user_id": i, "attempt": i % 3})
+	}
+}

--- a/log/z_log_test.go
+++ b/log/z_log_test.go
@@ -63,6 +63,28 @@ func TestWithDisabled(t *testing.T) {
 	assert.Equal(t, string(log.GetEventBuf(evt)), "")
 }
 
+func TestWithLoggerHandlesNilInputs(t *testing.T) {
+	var buf bytes.Buffer
+	var ctx context.Context
+	ctx = log.WithLogger(ctx, log.Output(&buf))
+
+	log.FromCtx(ctx).Info().Msg("with logger helper")
+	assert.Contains(t, buf.String(), "with logger helper")
+
+	buf.Reset()
+	log.Info(ctx).Msg("global helper uses ctx logger")
+	assert.Contains(t, buf.String(), "global helper uses ctx logger")
+
+	assert.NotPanics(t, func() {
+		assert.NotNil(t, log.FromCtx(log.WithLogger(ctx, nil)))
+	})
+}
+
+func TestFromCtxFallsBackToDefaultLogger(t *testing.T) {
+	var ctx context.Context
+	assert.NotNil(t, log.FromCtx(ctx))
+}
+
 func TestName(t *testing.T) {
 	log.Debug().Str("hello", "world world").Msg("ok ok")
 	log.Print("world world")
@@ -104,6 +126,84 @@ func TestEvent(t *testing.T) {
 	t.Run("update event ctx", func(t *testing.T) {
 		log.Info(log.UpdateFieldsCtx(getCtx(getEvt()), log.Fields{"add-update-event": "ok"})).Send()
 	})
+
+	t.Run("with fields helper", func(t *testing.T) {
+		ctx := log.WithFields(getCtx(getEvt()), log.Fields{"via": "helper"})
+		log.Info(ctx).Send()
+		assert.Equal(t, "helper", log.GetFieldsFromCtx(ctx)["via"])
+	})
+}
+
+func TestWithFieldsHandlesNilContext(t *testing.T) {
+	var ctx context.Context
+	ctx = log.WithFields(ctx, log.Fields{"request_id": "req-nil"})
+	fields := log.GetFieldsFromCtx(ctx)
+
+	assert.Equal(t, "req-nil", fields["request_id"])
+}
+
+func TestGetFieldsFromCtxHandlesNilContext(t *testing.T) {
+	var ctx context.Context
+
+	assert.NotPanics(t, func() {
+		assert.Nil(t, log.GetFieldsFromCtx(ctx))
+	})
+}
+
+func TestCreateFieldsCtxClonesInputMap(t *testing.T) {
+	source := log.Fields{"request_id": "req-source", "scope": "original"}
+	ctx := log.CreateFieldsCtx(context.Background(), source)
+
+	source["request_id"] = "req-mutated"
+	source["added_later"] = true
+
+	fields := log.GetFieldsFromCtx(ctx)
+	assert.Equal(t, "req-source", fields["request_id"])
+	assert.Equal(t, "original", fields["scope"])
+	assert.False(t, gjson.ParseBytes(mustEventJSON(t, fields)).Get("added_later").Exists())
+}
+
+func TestUpdateFieldsCtxDoesNotMutateParent(t *testing.T) {
+	base := log.CreateFieldsCtx(context.Background(), log.Fields{"request_id": "req-1"})
+	updated := log.UpdateFieldsCtx(base, log.Fields{"user_id": 42})
+
+	baseFields := log.GetFieldsFromCtx(base)
+	updatedFields := log.GetFieldsFromCtx(updated)
+
+	assert.Equal(t, "req-1", baseFields["request_id"])
+	assert.Nil(t, baseFields["user_id"])
+	assert.Equal(t, "req-1", updatedFields["request_id"])
+	assert.Equal(t, float64(42), gjson.ParseBytes(mustEventJSON(t, updatedFields)).Get("user_id").Float())
+}
+
+func TestWithFieldsLatestWinsWithoutMutatingBaseLogger(t *testing.T) {
+	base := log.GetLogger("fields-base").WithFields(log.Fields{"component": "base", "shared": "base"})
+	child := base.WithFields(log.Fields{"shared": "child", "request_id": "req-1"})
+
+	childEvent := eventJSON(t, child.Info())
+	assert.Equal(t, "base", childEvent.Get("component").String())
+	assert.Equal(t, "child", childEvent.Get("shared").String())
+	assert.Equal(t, "req-1", childEvent.Get("request_id").String())
+
+	baseEvent := eventJSON(t, base.Info())
+	assert.Equal(t, "base", baseEvent.Get("component").String())
+	assert.Equal(t, "base", baseEvent.Get("shared").String())
+	assert.False(t, baseEvent.Get("request_id").Exists())
+}
+
+func TestContextFieldsDoNotPolluteLoggerDefaults(t *testing.T) {
+	logger := log.GetLogger("ctx-merge").WithFields(log.Fields{"component": "worker", "scope": "logger"})
+	ctx := log.CreateFieldsCtx(context.Background(), log.Fields{"scope": "ctx", "request_id": "req-2"})
+
+	withCtx := eventJSON(t, logger.Info(ctx))
+	assert.Equal(t, "worker", withCtx.Get("component").String())
+	assert.Equal(t, "ctx", withCtx.Get("scope").String())
+	assert.Equal(t, "req-2", withCtx.Get("request_id").String())
+
+	withoutCtx := eventJSON(t, logger.Info())
+	assert.Equal(t, "worker", withoutCtx.Get("component").String())
+	assert.Equal(t, "logger", withoutCtx.Get("scope").String())
+	assert.False(t, withoutCtx.Get("request_id").Exists())
 }
 
 func TestWithEvent(t *testing.T) {
@@ -123,6 +223,10 @@ func TestSetLog(t *testing.T) {
 }
 
 func TestChecker(t *testing.T) {
+	t.Cleanup(func() {
+		log.SetEnableChecker(nil)
+	})
+
 	l := log.GetLogger("test-checker")
 	l.Info().Msg("hello")
 
@@ -151,4 +255,27 @@ func TestError(t *testing.T) {
 	err1 := errors.Errorf("test errors format")
 	log.Error().Err(err1).Msg("raw error: " + err1.Error())
 	log.Err(err1).Msg(err1.Error())
+}
+
+func TestRecordErrIgnoresNil(t *testing.T) {
+	var buf bytes.Buffer
+	record := log.RecordErr(log.Output(&buf))
+
+	assert.NotPanics(t, func() {
+		assert.Nil(t, record(context.Background(), nil))
+	})
+	assert.Empty(t, buf.String())
+}
+
+func eventJSON(t *testing.T, evt *log.Event) gjson.Result {
+	t.Helper()
+
+	return gjson.ParseBytes(log.GetEventBuf(evt))
+}
+
+func mustEventJSON(t *testing.T, fields log.Fields) []byte {
+	t.Helper()
+
+	evt := log.NewEvent().Fields(fields)
+	return log.GetEventBuf(evt)
 }

--- a/log/z_slog_test.go
+++ b/log/z_slog_test.go
@@ -1,10 +1,14 @@
 package log_test
 
 import (
+	"bytes"
+	"context"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/pubgo/funk/v2/log"
 	"github.com/pubgo/funk/v2/log/slogutil"
@@ -17,3 +21,27 @@ func TestSlog(t *testing.T) {
 		evt.Str("record", "ok")
 	}))
 }
+
+func TestSlogNilLoggerFallsBackSafely(t *testing.T) {
+	var ctx context.Context
+
+	assert.NotPanics(t, func() {
+		h := log.NewSlog(nil)
+		assert.True(t, h.Enabled(ctx, slog.LevelInfo))
+	})
+}
+
+func TestSlogEnabledUsesContextLoggerWithoutPanic(t *testing.T) {
+	var buf bytes.Buffer
+	var ctx context.Context
+	ctx = log.WithLogger(ctx, log.Output(&buf))
+	h := log.NewSlog(log.FromCtx(ctx))
+
+	assert.True(t, h.Enabled(ctx, slog.LevelInfo))
+	assert.NotPanics(t, func() {
+		assert.NoError(t, h.Handle(ctx, slog.NewRecord(testTime(), slog.LevelInfo, "ctx slog", 0)))
+	})
+	assert.Contains(t, buf.String(), "ctx slog")
+}
+
+func testTime() (t time.Time) { return }

--- a/log/z_stdlog_test.go
+++ b/log/z_stdlog_test.go
@@ -1,7 +1,10 @@
 package log_test
 
 import (
+	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/pubgo/funk/v2/log"
 )
@@ -10,4 +13,19 @@ func TestStdLog(t *testing.T) {
 	log.NewStd(log.GetLogger("with_event").
 		WithFields(log.Fields{"hello": "world", "int": 100})).
 		Print("dddd")
+}
+
+func TestStdLogNilLoggerFallsBackSafely(t *testing.T) {
+	assert.NotPanics(t, func() {
+		log.NewStd(nil).Print("fallback")
+	})
+}
+
+func TestStdLogPrintlnAddsSpaces(t *testing.T) {
+	var buf bytes.Buffer
+	std := log.NewStd(log.Output(&buf))
+
+	std.Println("hello", "world")
+	assert.Contains(t, buf.String(), "hello world")
+	assert.NotContains(t, buf.String(), "helloworld")
 }


### PR DESCRIPTION
## Summary

Improve `log` package ergonomics, fix context/field merging mutation bugs, and harden slog/std adapters.

- Fix logger pollution when merging context fields into log events (`maps.Clone` in `newEvent`)
- Implement missing `WithFields(ctx, ...)` API (documented on `v2` but not exported before)
- Add nil-safe helpers: `WithLogger`, `FromCtx`, and context-aware global helpers (`log.Info(ctx)`, etc.)
- Make context field maps immutable: clone on `CreateFieldsCtx` / `UpdateFieldsCtx`
- Fix `Logger.WithFields` precedence so caller fields override base logger defaults
- Harden adapters: `NewSlog(nil)` / `NewStd(nil)` fallback, slog `Enabled` no longer panics, `Println` spacing matches stdlib
- Add regression tests and benchmarks; expand README (EN/ZH)

## Behavior notes (minor breaking changes)

- `Logger.WithFields(m)`: caller fields now win over base logger fields (was reversed)
- `SetEnableChecker(nil)`: now clears the checker (previously a no-op)
- Global helpers (`log.Info(ctx)`, etc.) honor the logger stored in context

## Test plan

- [x] `go test ./log/...`
- [x] CI Release on GitHub
- [x] Regression tests for context field cloning, logger non-pollution, nil-safe helpers
- [x] Benchmarks in `z_bench_test.go` for context merge and context-aware logging