### PR TITLE
fix(result): improve ergonomics, safety, and test coverage

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint & Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, v2 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, v2 ]
 
 jobs:
 

--- a/result/README.md
+++ b/result/README.md
@@ -10,6 +10,21 @@ The result module provides functional programming-inspired error handling throug
 - **Async Support**: Future types for asynchronous computations
 - **Standard Compatibility**: Works with existing Go error handling patterns
 
+## Design Notes
+
+- `Result[T]` and `Error` intentionally disallow `==` comparisons; use `IsOK` / `IsErr` instead.
+- `Fail[T](err)` requires a non-nil error. Passing `nil` is treated as a programming mistake and panics.
+- `ErrOf(nil)` and `Error{}` represent the absence of an error, similar to a successful `Error` value.
+- `FlatMap` is the primary chaining name for `MapVal`; both names call the same implementation.
+- `MapValTo` / `FlatMapTo` are package-level helpers for changing the result value type.
+- `UnwrapErr()` follows standard Go `(T, error)` semantics: success returns `(value, nil)`, failure returns `(zero, err)`.
+- `WithErrorf(...)` always replaces the current result with a formatted error and discards any successful value.
+- `Throw` / `UnwrapOrThrow` propagate errors through `ErrSetter` targets such as `*Result[T]`, `*Error`, and `ProxyErr`.
+- `Collect` and `All` both gather many results; `All` is the variadic convenience form of `Collect`.
+- `Future.Await(ctx)` returns a completed value even when `ctx` is already cancelled, as long as the work finished first.
+- `Error.MarshalJSON` encodes success as JSON `null` and encodes failures with the enriched `errors` JSON format.
+- `Result[T].MarshalJSON` encodes successful values directly and returns a marshal error when the result failed.
+
 ## Installation
 
 ```bash
@@ -230,9 +245,11 @@ result := future.Await(ctx)
 
 1. **Prefer Result[T] over (T, error)**: For better composability and fewer nil checks
 2. **Use TryUnwrap for Safe Extraction**: Avoid panics in uncertain situations
-3. **Chain Operations for Readability**: Use Map/FlatMap for data transformation pipelines
+3. **Chain Operations for Readability**: Use `Map` / `FlatMap` for data transformation pipelines
 4. **Handle Errors Appropriately**: Use Match for exhaustive error handling
-5. **Leverage Async for IO-bound Operations**: Use Future[T] for non-blocking computations
+5. **Leverage Async for IO-bound Operations**: Use `Future[T]` for non-blocking computations
+6. **Never Pass nil to Fail**: Use `ErrOf(nil)` when you mean “no error” on the error-only path
+7. **Pass Pointers to Throw Targets**: `Throw(&r)` requires a setter that can be updated in place
 
 ## API Reference
 
@@ -241,7 +258,7 @@ result := future.Await(ctx)
 | Function | Description |
 |----------|-------------|
 | `OK(v T)` | Create successful result |
-| `Fail[T](err error)` | Create failed result |
+| `Fail[T](err error)` | Create failed result; `err` must be non-nil |
 | `Wrap(v T, err error)` | Create from value/error pair |
 | `WrapFn(fn func() (T, error))` | Create from function |
 
@@ -259,6 +276,7 @@ result := future.Await(ctx)
 |--------|-------------|
 | `Map(func(T) T)` | Transform successful value |
 | `FlatMap(func(T) Result[T])` | Transform with potential new errors |
+| `MapVal(func(T) Result[T])` | Alias of `FlatMap` |
 | `Validate(func(T) error)` | Validate with potential error |
 
 ### Result[T] Consumption
@@ -266,6 +284,7 @@ result := future.Await(ctx)
 | Method | Description |
 |--------|-------------|
 | `Unwrap() T` | Get value or panic |
+| `UnwrapErr() (T, error)` | Convert to standard Go `(T, error)` |
 | `UnwrapOr(default T) T` | Get value or default |
 | `Expect(msg string) T` | Get value or panic with message |
 

--- a/result/README.zh.md
+++ b/result/README.zh.md
@@ -10,6 +10,21 @@
 - **异步支持**: Future类型用于异步计算
 - **标准兼容性**: 与现有Go错误处理模式协作
 
+## 设计说明
+
+- `Result[T]` 和 `Error` 有意禁止 `==` 比较；请使用 `IsOK` / `IsErr`。
+- `Fail[T](err)` 要求 `err` 非 nil；传入 `nil` 会被视为编程错误并 panic。
+- `ErrOf(nil)` 与 `Error{}` 表示“没有错误”，对应 error-only 路径的成功状态。
+- `FlatMap` 是 `MapVal` 的主推荐命名，两者实现相同。
+- `MapValTo` / `FlatMapTo` 是包级 helper，用于在链式转换时改变值类型。
+- `UnwrapErr()` 遵循标准 Go `(T, error)` 语义：成功返回 `(value, nil)`，失败返回 `(zero, err)`。
+- `WithErrorf(...)` 会丢弃当前成功值，并替换为格式化错误。
+- `Throw` / `UnwrapOrThrow` 通过 `ErrSetter` 目标传播错误，例如 `*Result[T]`、`*Error`、`ProxyErr`。
+- `Collect` 与 `All` 都可聚合多个结果；`All` 是 `Collect` 的可变参数便捷形式。
+- 当异步任务已经完成时，即使 `ctx` 已取消，`Future.Await(ctx)` 仍会返回完成后的值。
+- `Error.MarshalJSON` 在成功时编码为 JSON `null`，失败时使用 enriched `errors` JSON。
+- `Result[T].MarshalJSON` 在成功时直接编码值，失败时返回 marshal error。
+
 ## 安装
 
 ```bash
@@ -230,9 +245,11 @@ result := future.Await(ctx)
 
 1. **优先使用Result[T]而非(T, error)**: 为了更好的组合性和更少的nil检查
 2. **使用TryUnwrap进行安全提取**: 在不确定的情况下避免panic
-3. **链式操作以提高可读性**: 使用Map/FlatMap进行数据转换管道
+3. **链式操作以提高可读性**: 使用 `Map` / `FlatMap` 进行数据转换管道
 4. **适当处理错误**: 使用Match进行详尽的错误处理
-5. **利用Async进行IO绑定操作**: 使用Future[T]进行非阻塞计算
+5. **利用Async进行IO绑定操作**: 使用 `Future[T]` 进行非阻塞计算
+6. **不要向 Fail 传 nil**: 若表示“没有错误”，在 error-only 路径上使用 `ErrOf(nil)`
+7. **向 Throw 传入可写指针**: `Throw(&r)` 需要能原地更新的 setter
 
 ## API参考
 
@@ -241,7 +258,7 @@ result := future.Await(ctx)
 | 函数 | 描述 |
 |------|------|
 | `OK(v T)` | 创建成功结果 |
-| `Fail[T](err error)` | 创建失败结果 |
+| `Fail[T](err error)` | 创建失败结果；`err` 必须非 nil |
 | `Wrap(v T, err error)` | 从值/错误对创建 |
 | `WrapFn(fn func() (T, error))` | 从函数创建 |
 
@@ -259,6 +276,7 @@ result := future.Await(ctx)
 |------|------|
 | `Map(func(T) T)` | 转换成功值 |
 | `FlatMap(func(T) Result[T])` | 转换带潜在新错误 |
+| `MapVal(func(T) Result[T])` | `FlatMap` 的别名 |
 | `Validate(func(T) error)` | 验证带潜在错误 |
 
 ### Result[T] 消费
@@ -266,6 +284,7 @@ result := future.Await(ctx)
 | 方法 | 描述 |
 |------|------|
 | `Unwrap() T` | 获取值或panic |
+| `UnwrapErr() (T, error)` | 转为标准 Go `(T, error)` |
 | `UnwrapOr(default T) T` | 获取值或默认值 |
 | `Expect(msg string) T` | 获取值或带消息panic |
 

--- a/result/api.go
+++ b/result/api.go
@@ -86,7 +86,7 @@ func OK[T any](v T) Result[T] {
 
 func Fail[T any](err error) Result[T] {
 	if err == nil {
-		return Result[T]{}
+		panicIfError(errors.WrapCaller(errors.New("result.Fail called with nil error"), 1))
 	}
 
 	err = errors.WrapCaller(err, 1)
@@ -144,6 +144,12 @@ func MapValTo[T, U any](r Result[T], fn func(T) Result[U]) Result[U] {
 	}
 
 	return fn(r.getValue())
+}
+
+// FlatMapTo transforms a successful value with fn and propagates the first error.
+// It is an alias of MapValTo for callers who prefer the FlatMap naming convention.
+func FlatMapTo[T, U any](r Result[T], fn func(T) Result[U]) Result[U] {
+	return MapValTo(r, fn)
 }
 
 func LogErr(err error, events ...func(e Event)) {

--- a/result/api.go
+++ b/result/api.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pubgo/funk/v2/errors"
 	"github.com/pubgo/funk/v2/errors/errparser"
+	"github.com/pubgo/funk/v2/stack"
 )
 
 func Run(executors ...func() error) Error {
@@ -34,7 +35,23 @@ func RecoveryErr(setter *error, callbacks ...func(err error) error) {
 		return
 	}
 
-	err := errRecovery(func() error { return *setter }, callbacks...)
+	err := errparser.Parse(recover())
+	if err == nil {
+		err = *setter
+	}
+
+	if err == nil {
+		return
+	}
+
+	for _, fn := range callbacks {
+		err = fn(err)
+		if err == nil {
+			return
+		}
+	}
+
+	stack.Print()
 	setError(ErrProxyOf(setter), errors.WrapCaller(err, 1))
 }
 
@@ -44,7 +61,23 @@ func Recovery(setter ErrSetter, callbacks ...func(err error) error) {
 		return
 	}
 
-	err := errRecovery(func() error { return setter.GetErr() }, callbacks...)
+	err := errparser.Parse(recover())
+	if err == nil {
+		err = setter.GetErr()
+	}
+
+	if err == nil {
+		return
+	}
+
+	for _, fn := range callbacks {
+		err = fn(err)
+		if err == nil {
+			return
+		}
+	}
+
+	stack.Print()
 	setError(setter, errors.WrapCaller(err, 1))
 }
 

--- a/result/error.go
+++ b/result/error.go
@@ -111,6 +111,10 @@ func (e Error) WithFn(fn func() error) Error {
 }
 
 func (e Error) WithErr(err error, tags ...errors.Tags) Error {
+	if err == nil {
+		return e
+	}
+
 	return Error{err: errors.WrapTagsCaller(err, lo.FirstOrEmpty(tags), 1)}
 }
 
@@ -191,11 +195,18 @@ func (e Error) String() string {
 }
 
 func (e Error) MarshalJSON() ([]byte, error) {
-	if e.IsErr() {
-		return nil, errors.WrapCaller(e.err, 1)
+	if e.IsOK() {
+		return []byte("null"), nil
 	}
 
 	return errors.JsonPrint(e.err), nil
+}
+
+func (e *Error) applyErr(err error) {
+	if err == nil {
+		return
+	}
+	e.err = err
 }
 
 func (e Error) getErr() error { return e.err }

--- a/result/error.go
+++ b/result/error.go
@@ -203,7 +203,7 @@ func (e Error) MarshalJSON() ([]byte, error) {
 }
 
 func (e *Error) applyErr(err error) {
-	if err == nil {
+	if e == nil || err == nil {
 		return
 	}
 	e.err = err

--- a/result/future.go
+++ b/result/future.go
@@ -48,11 +48,20 @@ func (f *Future[T]) setVal(val Result[T]) { f.v = val }
 
 func (f *Future[T]) Await(ctxL ...context.Context) Result[T] {
 	ctx := lo.FirstOr(ctxL, context.Background())
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	select {
 	case <-f.done:
 		return f.v
 	case <-ctx.Done():
-		return f.v.WithErr(ctx.Err())
+		select {
+		case <-f.done:
+			return f.v
+		default:
+			return Fail[T](ctx.Err())
+		}
 	}
 }
 
@@ -70,10 +79,19 @@ func (f *FutureErr) setErr(err error) { f.e = err }
 
 func (f *FutureErr) Await(ctxL ...context.Context) Error {
 	ctx := lo.FirstOr(ctxL, context.Background())
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	select {
 	case <-f.done:
 		return ErrOf(f.e)
 	case <-ctx.Done():
-		return ErrOf(ctx.Err())
+		select {
+		case <-f.done:
+			return ErrOf(f.e)
+		default:
+			return ErrOf(ctx.Err())
+		}
 	}
 }

--- a/result/future.go
+++ b/result/future.go
@@ -10,7 +10,7 @@ import (
 
 func AsyncErr(fn func() Error) *FutureErr {
 	if fn == nil {
-		return &FutureErr{e: errors.WrapCaller(errFnIsNil, 1)}
+		return completedErrFuture(errors.WrapCaller(errFnIsNil, 1))
 	}
 
 	future := newErrFuture()
@@ -23,7 +23,7 @@ func AsyncErr(fn func() Error) *FutureErr {
 
 func Async[T any](fn func() Result[T]) *Future[T] {
 	if fn == nil {
-		return &Future[T]{v: Fail[T](errors.WrapCaller(errFnIsNil, 1))}
+		return completedFuture(Fail[T](errors.WrapCaller(errFnIsNil, 1)))
 	}
 
 	future := newFuture[T]()
@@ -31,6 +31,20 @@ func Async[T any](fn func() Result[T]) *Future[T] {
 		defer future.close()
 		future.setVal(tryResult(fn))
 	}()
+	return future
+}
+
+func completedFuture[T any](val Result[T]) *Future[T] {
+	future := newFuture[T]()
+	future.setVal(val)
+	future.close()
+	return future
+}
+
+func completedErrFuture(err error) *FutureErr {
+	future := newErrFuture()
+	future.setErr(err)
+	future.close()
 	return future
 }
 

--- a/result/interface.go
+++ b/result/interface.go
@@ -15,6 +15,7 @@ type Checkable interface {
 type ErrSetter interface {
 	Checkable
 	setErrorInner()
+	applyErr(error)
 }
 
 type Void = funk.Void

--- a/result/proxy.go
+++ b/result/proxy.go
@@ -38,3 +38,10 @@ func (e ProxyErr) String() string {
 
 func (e ProxyErr) setErrorInner() {
 }
+
+func (e ProxyErr) applyErr(err error) {
+	if err == nil || e.err == nil {
+		return
+	}
+	*e.err = err
+}

--- a/result/result.go
+++ b/result/result.go
@@ -134,7 +134,8 @@ func (r Result[T]) Unwrap() T {
 	return r.getValue()
 }
 
-// UnwrapErr returns the value and error if it's OK, or the zero value and nil error if it's an error.
+// UnwrapErr returns the value and a nil error when the result is OK,
+// or the zero value and the underlying error when the result failed.
 func (r Result[T]) UnwrapErr() (T, error) {
 	if r.IsErr() {
 		var zero T
@@ -202,7 +203,7 @@ func (r Result[T]) UnwrapOrThrow(setter ErrSetter, contexts ...context.Context) 
 	return ret
 }
 
-// CallIfOK calls the provided function with the value if the result is OK,
+// CallIfOK calls fn with the value when the result is OK and propagates any returned error.
 func (r Result[T]) CallIfOK(fn func(val T) error) Result[T] {
 	if r.IsErr() {
 		return r
@@ -278,7 +279,7 @@ func (r Result[T]) Log(events ...func(e Event)) Result[T] {
 	return r
 }
 
-// Validate calls fn with the value if the result is OK, then returns the result unchanged.
+// Validate runs fn on the successful value and returns a failed result when validation fails.
 func (r Result[T]) Validate(fn func(val T) error) Result[T] {
 	if r.IsErr() {
 		return r
@@ -292,7 +293,7 @@ func (r Result[T]) Validate(fn func(val T) error) Result[T] {
 	return OK(val)
 }
 
-// Map calls fn with the value if the result is OK, then returns the result unchanged.
+// Map transforms the successful value and preserves any existing error.
 func (r Result[T]) Map(fn func(val T) T) Result[T] {
 	if r.IsErr() {
 		return r
@@ -300,7 +301,7 @@ func (r Result[T]) Map(fn func(val T) T) Result[T] {
 	return OK(fn(r.getValue()))
 }
 
-// MapVal calls fn with the value if the result is OK, then returns the result unchanged.
+// MapVal transforms the successful value with fn and propagates the first error.
 func (r Result[T]) MapVal(fn func(val T) Result[T]) Result[T] {
 	if r.IsErr() {
 		return r
@@ -308,7 +309,12 @@ func (r Result[T]) MapVal(fn func(val T) Result[T]) Result[T] {
 	return fn(r.getValue())
 }
 
-// MapErr calls fn with the error if the result is an error, then returns the result unchanged.
+// FlatMap is an alias of MapVal for callers who prefer the FlatMap naming convention.
+func (r Result[T]) FlatMap(fn func(val T) Result[T]) Result[T] {
+	return r.MapVal(fn)
+}
+
+// MapErr transforms the error when the result failed and leaves successful values unchanged.
 func (r Result[T]) MapErr(fn func(err error) error) Result[T] {
 	if r.IsOK() {
 		return r
@@ -316,7 +322,7 @@ func (r Result[T]) MapErr(fn func(err error) error) Result[T] {
 	return Fail[T](fn(r.getErr()))
 }
 
-// MapErrOr calls fn with the error if the result is an error, then returns the result unchanged.
+// MapErrOr transforms the error with fn when the result failed and returns the produced result.
 func (r Result[T]) MapErrOr(fn func(err error) Result[T]) Result[T] {
 	if r.IsOK() {
 		return r
@@ -344,7 +350,7 @@ func (r Result[T]) String() string {
 	return fmt.Sprintf("Error(%v)", r.getErr())
 }
 
-// WithErrorf returns a new Result with the provided error message.
+// WithErrorf replaces the result with a formatted error and discards any successful value.
 func (r Result[T]) WithErrorf(format string, args ...any) Result[T] {
 	err := fmt.Errorf(format, args...)
 	err = errors.WrapCaller(err, 1)
@@ -375,4 +381,12 @@ func (r Result[T]) getValue() T { return lo.FromPtr(r.v) }
 func (r Result[T]) getErr() error { return r.err }
 
 func (r Result[T]) setErrorInner() {
+}
+
+func (r *Result[T]) applyErr(err error) {
+	if err == nil {
+		return
+	}
+	r.err = err
+	r.v = nil
 }

--- a/result/result.go
+++ b/result/result.go
@@ -384,7 +384,7 @@ func (r Result[T]) setErrorInner() {
 }
 
 func (r *Result[T]) applyErr(err error) {
-	if err == nil {
+	if r == nil || err == nil {
 		return
 	}
 	r.err = err

--- a/result/resultchecker/checker.go
+++ b/result/resultchecker/checker.go
@@ -2,11 +2,16 @@ package resultchecker
 
 import (
 	"context"
+	"slices"
+	"sync"
 
 	"github.com/pubgo/funk/v2/stack"
 )
 
-var errChecks []ErrChecker
+var (
+	errChecksMu sync.RWMutex
+	errChecks   []ErrChecker
+)
 
 func RegisterErrCheck(f ErrChecker) bool {
 	if f == nil {
@@ -14,6 +19,10 @@ func RegisterErrCheck(f ErrChecker) bool {
 	}
 
 	checkFrame := stack.CallerWithFunc(f).String()
+
+	errChecksMu.Lock()
+	defer errChecksMu.Unlock()
+
 	for _, errFunc := range errChecks {
 		if checkFrame == stack.CallerWithFunc(errFunc).String() {
 			return false
@@ -24,10 +33,18 @@ func RegisterErrCheck(f ErrChecker) bool {
 	return true
 }
 
-func GetErrChecks() []ErrChecker { return errChecks }
+func GetErrChecks() []ErrChecker {
+	errChecksMu.RLock()
+	defer errChecksMu.RUnlock()
+
+	return slices.Clone(errChecks)
+}
 
 func GetErrCheckStacks() []*stack.Frame {
-	var frames = make([]*stack.Frame, 0, len(errChecks))
+	errChecksMu.RLock()
+	defer errChecksMu.RUnlock()
+
+	frames := make([]*stack.Frame, 0, len(errChecks))
 	for _, err := range errChecks {
 		frames = append(frames, stack.CallerWithFunc(err))
 	}
@@ -36,6 +53,10 @@ func GetErrCheckStacks() []*stack.Frame {
 
 func RemoveErrCheck(f func(context.Context, error) error) {
 	checkFrame := stack.CallerWithFunc(f).String()
+
+	errChecksMu.Lock()
+	defer errChecksMu.Unlock()
+
 	index := -1
 	for idx, errFunc := range errChecks {
 		if checkFrame == stack.CallerWithFunc(errFunc).String() {

--- a/result/resultchecker/checker_concurrent_test.go
+++ b/result/resultchecker/checker_concurrent_test.go
@@ -1,0 +1,39 @@
+package resultchecker_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pubgo/funk/v2/result/resultchecker"
+)
+
+func TestRegisterErrCheckConcurrent(t *testing.T) {
+	t.Cleanup(func() {
+		resultchecker.RemoveErrCheck(checkA)
+		resultchecker.RemoveErrCheck(checkB)
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				resultchecker.RegisterErrCheck(checkA)
+			} else {
+				resultchecker.RegisterErrCheck(checkB)
+			}
+			_ = resultchecker.GetErrChecks()
+		}(i)
+	}
+	wg.Wait()
+
+	checks := resultchecker.GetErrChecks()
+	assert.GreaterOrEqual(t, len(checks), 1)
+}
+
+func checkA(context.Context, error) error { return nil }
+func checkB(context.Context, error) error { return nil }

--- a/result/resultchecker/context_test.go
+++ b/result/resultchecker/context_test.go
@@ -1,0 +1,21 @@
+package resultchecker_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pubgo/funk/v2/result/resultchecker"
+)
+
+func TestCreateCtxAndGetCheckersFromCtx(t *testing.T) {
+	check := func(context.Context, error) error { return nil }
+
+	ctx := resultchecker.CreateCtx(nil, []resultchecker.ErrChecker{check})
+	got := resultchecker.GetCheckersFromCtx(ctx)
+	assert.Len(t, got, 1)
+
+	assert.Nil(t, resultchecker.GetCheckersFromCtx(nil))
+	assert.Nil(t, resultchecker.GetCheckersFromCtx(context.Background()))
+}

--- a/result/util.go
+++ b/result/util.go
@@ -3,11 +3,6 @@ package result
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"reflect"
-	"runtime/debug"
-	"strings"
-	"unsafe"
 
 	"github.com/rs/zerolog"
 	"github.com/samber/lo"
@@ -280,64 +275,7 @@ func setError(setter ErrSetter, err error) {
 		return
 	}
 
-	switch errSet := setter.(type) {
-	case *Error:
-		errSet.err = err
-	case *ProxyErr:
-		*errSet.err = err
-	case ProxyErr:
-		*errSet.err = err
-	default:
-		// Use reflection for generic Result[T] types
-		rv := reflect.ValueOf(setter)
-		if !rv.IsValid() || rv.IsNil() {
-			slog.Error("error setter is invalid or nil",
-				slog.String("type", fmt.Sprintf("%T", setter)),
-				slog.String("stack", string(debug.Stack())),
-			)
-			return
-		}
-
-		t := rv.Type()
-		typeStr := t.String()
-
-		// Check if it's a Result type (pointer or value)
-		if !strings.Contains(typeStr, "Result[") {
-			slog.Error("error setter type error, type is not Result",
-				slog.String("type", fmt.Sprintf("%T", setter)),
-				slog.String("type-string", typeStr),
-				slog.String("stack", string(debug.Stack())),
-			)
-			return
-		}
-
-		// Handle both *Result[T] and Result[T]
-		var resultPtr *Result[any]
-		if rv.Kind() == reflect.Ptr {
-			if rv.IsNil() {
-				slog.Error("error setter is nil pointer",
-					slog.String("type", typeStr),
-					slog.String("stack", string(debug.Stack())),
-				)
-				return
-			}
-			resultPtr = (*Result[any])(rv.UnsafePointer())
-		} else {
-			// For value types, get address
-			if !rv.CanAddr() {
-				slog.Error("error setter cannot get address",
-					slog.String("type", typeStr),
-					slog.String("stack", string(debug.Stack())),
-				)
-				return
-			}
-			resultPtr = (*Result[any])(unsafe.Pointer(rv.UnsafeAddr()))
-		}
-
-		if resultPtr != nil {
-			resultPtr.err = err
-		}
-	}
+	setter.applyErr(err)
 }
 
 var resultFile = stack.Caller(0)

--- a/result/util.go
+++ b/result/util.go
@@ -3,6 +3,7 @@ package result
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/rs/zerolog"
 	"github.com/samber/lo"
@@ -108,12 +109,16 @@ func catchErr(r Error, setter ErrSetter, rawSetter *error, contexts ...context.C
 		panicIfError(errors.Errorf("error setter is nil"))
 	}
 
+	if isNilErrSetter(setter) && rawSetter == nil {
+		return false
+	}
+
 	if r.IsOK() {
 		return false
 	}
 
 	isErr := func() bool {
-		if setter != nil {
+		if !isNilErrSetter(setter) {
 			return setter.IsErr()
 		}
 
@@ -125,7 +130,7 @@ func catchErr(r Error, setter ErrSetter, rawSetter *error, contexts ...context.C
 	}
 
 	getErr := func() error {
-		if setter != nil {
+		if !isNilErrSetter(setter) {
 			return setter.GetErr()
 		}
 
@@ -137,7 +142,7 @@ func catchErr(r Error, setter ErrSetter, rawSetter *error, contexts ...context.C
 	}
 
 	setErr := func(err error) {
-		if setter != nil {
+		if !isNilErrSetter(setter) {
 			setError(setter, err)
 		}
 
@@ -220,7 +225,7 @@ func errRecovery(getErr func() error, callbacks ...func(err error) error) error 
 //	T - The unwrapped value
 //	error - Any error that occurred during unwrapping
 func unwrapErr[T any](r Result[T], setter1 *error, setter2 ErrSetter, contexts ...context.Context) (T, error) {
-	if setter1 == nil && setter2 == nil {
+	if setter1 == nil && isNilErrSetter(setter2) {
 		panicIfError(fmt.Errorf("error setter is nil"))
 	}
 
@@ -236,7 +241,7 @@ func unwrapErr[T any](r Result[T], setter1 *error, setter2 ErrSetter, contexts .
 
 	getPreErr := func() error {
 		err := lo.FromPtr(setter1)
-		if err == nil {
+		if err == nil && !isNilErrSetter(setter2) {
 			err = setter2.GetErr()
 		}
 		return err
@@ -270,12 +275,26 @@ func setError(setter ErrSetter, err error) {
 		return
 	}
 
-	if setter == nil {
+	if isNilErrSetter(setter) {
 		panicIfError(errors.Errorf("error setter is nil"))
 		return
 	}
 
 	setter.applyErr(err)
+}
+
+func isNilErrSetter(setter ErrSetter) bool {
+	if setter == nil {
+		return true
+	}
+
+	v := reflect.ValueOf(setter)
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func:
+		return v.IsNil()
+	default:
+		return false
+	}
 }
 
 var resultFile = stack.Caller(0)

--- a/result/util.go
+++ b/result/util.go
@@ -176,18 +176,8 @@ func catchErr(r Error, setter ErrSetter, rawSetter *error, contexts ...context.C
 	return true
 }
 
-// errRecovery handles error recovery from panics
-// This function is used to recover from panics and convert them to errors.
-// It applies callback functions to transform the error if needed.
-//
-// Parameters:
-//
-//	getErr - A function that returns the current error (if any)
-//	callbacks - Optional functions to transform the error
-//
-// Returns:
-//
-//	error - The recovered error, or nil if no error occurred
+// errRecovery handles error recovery from panics when recover is called directly
+// in the deferred function. Prefer result.Recovery for deferred panic handling.
 func errRecovery(getErr func() error, callbacks ...func(err error) error) error {
 	err := errparser.Parse(recover())
 	if err == nil {

--- a/result/z_api_test.go
+++ b/result/z_api_test.go
@@ -1,0 +1,133 @@
+package result_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pubgo/funk/v2/errors"
+	"github.com/pubgo/funk/v2/recovery"
+	"github.com/pubgo/funk/v2/result"
+)
+
+func TestRunExecutesUntilFirstError(t *testing.T) {
+	calls := 0
+	err := result.Run(
+		func() error {
+			calls++
+			return nil
+		},
+		func() error {
+			calls++
+			return errors.New("stop")
+		},
+		func() error {
+			calls++
+			return nil
+		},
+	)
+
+	assert.True(t, err.IsErr())
+	assert.Equal(t, 2, calls)
+}
+
+func TestAllCollectsValuesOrStopsOnError(t *testing.T) {
+	ok := result.All(result.OK(1), result.OK(2), result.OK(3))
+	vals, okUnwrap := ok.TryUnwrap()
+	assert.True(t, okUnwrap)
+	assert.Equal(t, []int{1, 2, 3}, vals)
+
+	fail := result.All(result.OK(1), result.Fail[int](errors.New("broken")))
+	assert.True(t, fail.IsErr())
+}
+
+func TestWrapAndWrapFn(t *testing.T) {
+	ok := result.Wrap(7, nil)
+	val, err := ok.UnwrapErr()
+	assert.NoError(t, err)
+	assert.Equal(t, 7, val)
+
+	fail := result.Wrap(0, errors.New("wrap"))
+	assert.True(t, fail.IsErr())
+
+	fromFn := result.WrapFn(func() (int, error) { return 9, nil })
+	assert.Equal(t, 9, fromFn.UnwrapOrEmpty())
+
+	fromFnErr := result.WrapFn(func() (int, error) { return 0, errors.New("fn") })
+	assert.True(t, fromFnErr.IsErr())
+}
+
+func TestWrapErr(t *testing.T) {
+	val, err := result.WrapErr(5, nil)
+	assert.True(t, err.IsOK())
+	assert.Equal(t, 5, val)
+
+	_, err = result.WrapErr(0, errors.New("wrap err"))
+	assert.True(t, err.IsErr())
+}
+
+func TestErrOfFn(t *testing.T) {
+	assert.True(t, result.ErrOfFn(func() error { return nil }).IsOK())
+	assert.True(t, result.ErrOfFn(func() error { return errors.New("fn err") }).IsErr())
+}
+
+func TestMust1(t *testing.T) {
+	assert.Equal(t, 11, result.Must1(11, nil))
+
+	defer recovery.Testing(t)
+	assert.Panics(t, func() {
+		_ = result.Must1(0, errors.New("must1"))
+	})
+}
+
+func TestPackageThrowHelpers(t *testing.T) {
+	var r result.Result[string]
+	assert.True(t, result.Throw(&r, errors.New("pkg throw")))
+	assert.True(t, r.IsErr())
+
+	var raw error
+	assert.True(t, result.ThrowErr(&raw, errors.New("raw throw")))
+	assert.Error(t, raw)
+}
+
+func TestErrProxyOfPanicsOnNilPointer(t *testing.T) {
+	defer recovery.Testing(t)
+
+	assert.Panics(t, func() {
+		_ = result.ErrProxyOf(nil)
+	})
+}
+
+func TestMapToPropagatesError(t *testing.T) {
+	mapped := result.MapTo(result.Fail[int](errors.New("src")), func(v int) string {
+		return fmt.Sprintf("%d", v)
+	})
+	assert.True(t, mapped.IsErr())
+
+	ok := result.MapTo(result.OK(3), func(v int) string { return fmt.Sprintf("n=%d", v) })
+	assert.Equal(t, "n=3", ok.UnwrapOrEmpty())
+}
+
+func TestCollectAndPartitionEdgeCases(t *testing.T) {
+	empty := result.Collect([]result.Result[int]{})
+	vals, ok := empty.TryUnwrap()
+	assert.True(t, ok)
+	assert.Empty(t, vals)
+
+	values, errs := result.Partition([]result.Result[int]{
+		result.OK(1),
+		result.Fail[int](errors.New("e1")),
+	})
+	assert.Equal(t, []int{1}, values)
+	assert.Len(t, errs, 1)
+}
+
+func TestLogErrHelpers(t *testing.T) {
+	assert.NotPanics(t, func() {
+		result.LogErr(errors.New("log me"))
+		result.LogErrCtx(context.Background(), errors.New("log ctx"))
+		result.LogErr(nil)
+	})
+}

--- a/result/z_error_methods_test.go
+++ b/result/z_error_methods_test.go
@@ -1,0 +1,90 @@
+package result_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pubgo/funk/v2/errors"
+	"github.com/pubgo/funk/v2/recovery"
+	"github.com/pubgo/funk/v2/result"
+)
+
+func TestErrorWithFn(t *testing.T) {
+	assert.True(t, result.Error{}.WithFn(func() error { return nil }).IsOK())
+	assert.True(t, result.Error{}.WithFn(func() error { return errors.New("fn") }).IsErr())
+	assert.True(t, result.Error{}.WithFn(nil).IsErr())
+}
+
+func TestErrorWithErrorfAndMapErr(t *testing.T) {
+	err := result.Error{}.WithErrorf("formatted %s", "err")
+	assert.True(t, err.IsErr())
+	assert.Contains(t, err.Err().Error(), "formatted")
+
+	mapped := result.ErrOf(errors.New("root")).MapErr(func(err error) error {
+		return fmt.Errorf("mapped: %w", err)
+	})
+	assert.Contains(t, mapped.Err().Error(), "mapped")
+}
+
+func TestErrorMatchWithError(t *testing.T) {
+	err := result.ErrOf(errors.New("root")).MatchWithError(
+		func() error { return nil },
+		func(err error) error { return fmt.Errorf("wrapped: %w", err) },
+	)
+	assert.Contains(t, err.Error(), "wrapped")
+
+	ok := result.ErrOf(nil).MatchWithError(
+		func() error { return nil },
+		func(err error) error { return err },
+	)
+	assert.NoError(t, ok)
+}
+
+func TestErrorMustAndUnwrap(t *testing.T) {
+	assert.NotPanics(t, func() {
+		result.ErrOf(nil).Must()
+	})
+
+	defer recovery.Testing(t)
+	assert.Panics(t, func() {
+		result.ErrOf(errors.New("must")).Must()
+	})
+
+	assert.NotPanics(t, func() {
+		_ = result.ErrOf(nil).Unwrap()
+	})
+	assert.Panics(t, func() {
+		_ = result.ErrOf(errors.New("unwrap")).Unwrap()
+	})
+}
+
+func TestErrorExpectAndMustWithLog(t *testing.T) {
+	defer recovery.Testing(t)
+
+	assert.Panics(t, func() {
+		result.ErrOf(errors.New("expect")).Expect("failed %s", "now")
+	})
+
+	assert.NotPanics(t, func() {
+		result.ErrOf(nil).MustWithLog()
+	})
+	assert.Panics(t, func() {
+		result.ErrOf(errors.New("log")).MustWithLog()
+	})
+}
+
+func TestErrorGettersAndInspect(t *testing.T) {
+	err := result.ErrOf(errors.New("getter"))
+	assert.True(t, err.IsErr())
+	assert.Equal(t, "getter", err.GetErr().Error())
+	assert.Equal(t, "getter", err.Err().Error())
+	assert.Contains(t, err.String(), "getter")
+
+	called := false
+	err.InspectErr(func(error) { called = true })
+	assert.True(t, called)
+
+	assert.Equal(t, "OK", result.ErrOf(nil).String())
+}

--- a/result/z_future_await_test.go
+++ b/result/z_future_await_test.go
@@ -1,0 +1,56 @@
+package result_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pubgo/funk/v2/result"
+)
+
+func TestFutureAwaitPrefersCompletedValueOverCancelledContext(t *testing.T) {
+	future := result.Async(func() result.Result[int] {
+		return result.OK(42)
+	})
+
+	time.Sleep(20 * time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	r := future.Await(ctx)
+	val, ok := r.TryUnwrap()
+	require.True(t, ok, "completed work should win over cancelled context, got err=%v", r.Err())
+	assert.Equal(t, 42, val)
+}
+
+func TestFutureAwaitReturnsTimeoutWhenWorkIsSlow(t *testing.T) {
+	future := result.Async(func() result.Result[int] {
+		time.Sleep(200 * time.Millisecond)
+		return result.OK(42)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+
+	r := future.Await(ctx)
+	assert.True(t, r.IsErr())
+	assert.ErrorIs(t, r.Err(), context.DeadlineExceeded)
+}
+
+func TestErrFutureAwaitReturnsTimeoutWhenWorkIsSlow(t *testing.T) {
+	future := result.AsyncErr(func() result.Error {
+		time.Sleep(200 * time.Millisecond)
+		return result.ErrOf(nil)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+
+	r := future.Await(ctx)
+	assert.True(t, r.IsErr())
+	assert.ErrorIs(t, r.Err(), context.DeadlineExceeded)
+}

--- a/result/z_future_edge_test.go
+++ b/result/z_future_edge_test.go
@@ -1,0 +1,30 @@
+package result_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pubgo/funk/v2/result"
+)
+
+func TestAsyncNilFunctionReturnsError(t *testing.T) {
+	future := result.Async[int](nil)
+	r := future.Await()
+	assert.True(t, r.IsErr())
+}
+
+func TestAsyncErrNilFunctionReturnsError(t *testing.T) {
+	future := result.AsyncErr(nil)
+	r := future.Await()
+	assert.True(t, r.IsErr())
+}
+
+func TestFutureAwaitWithNilContextUsesBackground(t *testing.T) {
+	future := result.Async(func() result.Result[int] {
+		return result.OK(21)
+	})
+
+	r := future.Await(nil)
+	assert.Equal(t, 21, r.UnwrapOrEmpty())
+}

--- a/result/z_marshal_test.go
+++ b/result/z_marshal_test.go
@@ -97,10 +97,15 @@ func TestUnwrapErrSemantics(t *testing.T) {
 }
 
 func TestSetErrorClearsValueOnResult(t *testing.T) {
-	var r result.Result[int]
-	r = result.OK(99)
+	var r result.Result[int] = result.OK(99)
 
 	assert.True(t, result.ErrOf(errors.New("propagate")).Throw(&r))
 	assert.True(t, r.IsErr())
 	assert.Equal(t, 0, r.UnwrapOrEmpty())
+}
+
+func TestApplyErrIgnoresTypedNilSetter(t *testing.T) {
+	var r *result.Result[int]
+
+	assert.False(t, result.ErrOf(errors.New("noop")).Throw(r))
 }

--- a/result/z_marshal_test.go
+++ b/result/z_marshal_test.go
@@ -1,0 +1,106 @@
+package result_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pubgo/funk/v2/errors"
+	"github.com/pubgo/funk/v2/recovery"
+	"github.com/pubgo/funk/v2/result"
+)
+
+func TestResultMarshalJSON(t *testing.T) {
+	okBytes, err := json.Marshal(result.OK(42))
+	require.NoError(t, err)
+	assert.Equal(t, "42", string(okBytes))
+
+	fail := result.Fail[int](errors.New("boom"))
+	_, err = json.Marshal(fail)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestErrorMarshalJSON(t *testing.T) {
+	okBytes, err := json.Marshal(result.ErrOf(nil))
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(okBytes))
+
+	errBytes, err := json.Marshal(result.ErrOf(errors.New("marshal-me")))
+	require.NoError(t, err)
+	assert.Contains(t, string(errBytes), "marshal-me")
+}
+
+func TestFailNilPanics(t *testing.T) {
+	defer recovery.Testing(t)
+
+	assert.Panics(t, func() {
+		_ = result.Fail[int](nil)
+	})
+}
+
+func TestFlatMapAlias(t *testing.T) {
+	r := result.OK("hello").
+		FlatMap(func(s string) result.Result[string] {
+			return result.OK(s + " world")
+		})
+
+	val, ok := r.TryUnwrap()
+	assert.True(t, ok)
+	assert.Equal(t, "hello world", val)
+
+	short := result.OK("").
+		FlatMap(func(s string) result.Result[string] {
+			if s == "" {
+				return result.Fail[string](fmt.Errorf("empty"))
+			}
+			return result.OK(s)
+		})
+	assert.True(t, short.IsErr())
+}
+
+func TestFlatMapToAlias(t *testing.T) {
+	r := result.FlatMapTo(result.OK(2), func(v int) result.Result[string] {
+		return result.OK(fmt.Sprintf("n=%d", v))
+	})
+
+	val, ok := r.TryUnwrap()
+	assert.True(t, ok)
+	assert.Equal(t, "n=2", val)
+}
+
+func TestErrorWithErrNilPreservesState(t *testing.T) {
+	ok := result.ErrOf(nil).WithErr(nil)
+	assert.True(t, ok.IsOK())
+
+	err := result.ErrOf(errors.New("base")).WithErr(nil)
+	assert.True(t, err.IsErr())
+	assert.Equal(t, "base", err.Err().Error())
+}
+
+func TestWithErrorfDiscardsValue(t *testing.T) {
+	r := result.OK(1).WithErrorf("forced")
+	assert.True(t, r.IsErr())
+	assert.Contains(t, r.Err().Error(), "forced")
+}
+
+func TestUnwrapErrSemantics(t *testing.T) {
+	val, err := result.OK(42).UnwrapErr()
+	assert.NoError(t, err)
+	assert.Equal(t, 42, val)
+
+	_, err = result.Fail[int](errors.New("nope")).UnwrapErr()
+	assert.Error(t, err)
+}
+
+func TestSetErrorClearsValueOnResult(t *testing.T) {
+	var r result.Result[int]
+	r = result.OK(99)
+
+	assert.True(t, result.ErrOf(errors.New("propagate")).Throw(&r))
+	assert.True(t, r.IsErr())
+	assert.Equal(t, 0, r.UnwrapOrEmpty())
+}

--- a/result/z_propagation_test.go
+++ b/result/z_propagation_test.go
@@ -1,0 +1,109 @@
+package result_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pubgo/funk/v2/errors"
+	"github.com/pubgo/funk/v2/recovery"
+	"github.com/pubgo/funk/v2/result"
+	"github.com/pubgo/funk/v2/result/resultchecker"
+)
+
+func TestThrowPanicsOnNilSetter(t *testing.T) {
+	defer recovery.Testing(t)
+
+	assert.Panics(t, func() {
+		result.ErrOf(errors.New("boom")).Throw(nil)
+	})
+}
+
+func TestThrowErrUsesRawPointer(t *testing.T) {
+	var raw error
+	assert.True(t, result.ErrOf(errors.New("raw")).ThrowErr(&raw))
+	assert.Error(t, raw)
+}
+
+func TestThrowReturnsFalseForOKError(t *testing.T) {
+	var r result.Result[int]
+	assert.False(t, result.ErrOf(nil).Throw(&r))
+	assert.True(t, r.IsOK())
+}
+
+func TestThrowPropagatesToErrorSetter(t *testing.T) {
+	var e result.Error
+	assert.True(t, result.ErrOf(errors.New("to error")).Throw(&e))
+	assert.True(t, e.IsErr())
+}
+
+func TestThrowDoesNotOverwriteWhenCheckerSuppresses(t *testing.T) {
+	t.Cleanup(func() {
+		resultchecker.RemoveErrCheck(suppressErrCheck)
+	})
+	resultchecker.RegisterErrCheck(suppressErrCheck)
+
+	var r result.Result[int]
+	assert.False(t, result.ErrOf(errors.New("filtered")).Throw(&r))
+	assert.True(t, r.IsOK())
+}
+
+func TestThrowUsesContextChecker(t *testing.T) {
+	ctx := resultchecker.CreateCtx(context.Background(), []resultchecker.ErrChecker{suppressErrCheck})
+
+	var r result.Result[int]
+	assert.False(t, result.ErrOf(errors.New("filtered")).Throw(&r, ctx))
+	assert.True(t, r.IsOK())
+}
+
+func TestThrowLogsWhenSetterAlreadyHasError(t *testing.T) {
+	var r result.Result[int] = result.Fail[int](errors.New("existing"))
+
+	assert.NotPanics(t, func() {
+		assert.True(t, result.ErrOf(errors.New("next")).Throw(&r))
+	})
+	assert.True(t, r.IsErr())
+}
+
+func TestRecoveryCapturesPanic(t *testing.T) {
+	var r result.Error
+	func() {
+		defer result.Recovery(&r)
+		panic("boom")
+	}()
+	assert.True(t, r.IsErr())
+}
+
+func TestRecoveryErrCapturesPanic(t *testing.T) {
+	var raw error
+	func() {
+		defer result.RecoveryErr(&raw)
+		panic("boom")
+	}()
+	assert.Error(t, raw)
+}
+
+func TestRecoveryCallbackCanClearError(t *testing.T) {
+	var r result.Error
+	func() {
+		defer result.Recovery(&r, func(err error) error { return nil })
+		panic("boom")
+	}()
+	assert.True(t, r.IsOK())
+}
+
+func TestApplyErrOnTypedNilErrorSetter(t *testing.T) {
+	var e *result.Error
+
+	assert.False(t, result.ErrOf(errors.New("noop")).Throw(e))
+}
+
+func TestProxyErrApplyErrNilInnerPointer(t *testing.T) {
+	var proxy result.ProxyErr
+	assert.NotPanics(t, func() {
+		result.ErrOf(errors.New("noop")).Throw(&proxy)
+	})
+}
+
+func suppressErrCheck(context.Context, error) error { return nil }

--- a/result/z_result_chain_test.go
+++ b/result/z_result_chain_test.go
@@ -1,0 +1,156 @@
+package result_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pubgo/funk/v2/errors"
+	"github.com/pubgo/funk/v2/recovery"
+	"github.com/pubgo/funk/v2/result"
+)
+
+func TestResultMapAndValidate(t *testing.T) {
+	doubled := result.OK(2).Map(func(v int) int { return v * 2 })
+	assert.Equal(t, 4, doubled.UnwrapOrEmpty())
+
+	validated := result.OK("ok").Validate(func(s string) error {
+		if s == "" {
+			return errors.New("empty")
+		}
+		return nil
+	})
+	assert.True(t, validated.IsOK())
+
+	invalid := result.OK("").Validate(func(s string) error {
+		if s == "" {
+			return errors.New("empty")
+		}
+		return nil
+	})
+	assert.True(t, invalid.IsErr())
+}
+
+func TestResultMapErrVariants(t *testing.T) {
+	wrapped := result.Fail[int](errors.New("root")).MapErr(func(err error) error {
+		return fmt.Errorf("wrapped: %w", err)
+	})
+	assert.Contains(t, wrapped.Err().Error(), "wrapped")
+
+	replaced := result.Fail[int](errors.New("root")).MapErrOr(func(err error) result.Result[int] {
+		return result.OK(99)
+	})
+	assert.Equal(t, 99, replaced.UnwrapOrEmpty())
+
+	unchanged := result.OK(1).MapErr(func(err error) error { return err })
+	assert.Equal(t, 1, unchanged.UnwrapOrEmpty())
+}
+
+func TestResultFallbackHelpers(t *testing.T) {
+	assert.Equal(t, 5, result.Fail[int](errors.New("x")).Or(5).UnwrapOrEmpty())
+	assert.Equal(t, 6, result.Fail[int](errors.New("x")).UnwrapOr(6))
+	assert.Equal(t, 7, result.Fail[int](errors.New("x")).OrElse(func() int { return 7 }).UnwrapOrEmpty())
+	assert.Equal(t, 8, result.Fail[int](errors.New("x")).UnwrapOrElse(func() int { return 8 }))
+}
+
+func TestResultMatchWithResult(t *testing.T) {
+	doubled := result.OK(2).MatchWithResult(
+		func(v int) result.Result[int] { return result.OK(v * 2) },
+		func(err error) result.Result[int] { return result.Fail[int](err) },
+	)
+	assert.Equal(t, 4, doubled.UnwrapOrEmpty())
+
+	fromErr := result.Fail[int](errors.New("bad")).MatchWithResult(
+		func(v int) result.Result[int] { return result.OK(v) },
+		func(err error) result.Result[int] { return result.OK(-1) },
+	)
+	assert.Equal(t, -1, fromErr.UnwrapOrEmpty())
+}
+
+func TestResultWithFnAndWithValue(t *testing.T) {
+	chained := result.OK(1).WithFn(func() (int, error) { return 2, nil })
+	assert.Equal(t, 2, chained.UnwrapOrEmpty())
+
+	skipped := result.Fail[int](errors.New("base")).WithFn(func() (int, error) {
+		t.Fatal("should not run")
+		return 0, nil
+	})
+	assert.True(t, skipped.IsErr())
+
+	replaced := result.OK(1).WithValue(3)
+	assert.Equal(t, 3, replaced.UnwrapOrEmpty())
+}
+
+func TestResultValueTo(t *testing.T) {
+	var out int
+	err := result.OK(10).ValueTo(&out)
+	assert.True(t, err.IsOK())
+	assert.Equal(t, 10, out)
+
+	err = result.Fail[int](errors.New("bad")).ValueTo(&out)
+	assert.True(t, err.IsErr())
+
+	err = result.OK(1).ValueTo(nil)
+	assert.True(t, err.IsErr())
+}
+
+func TestResultInspectHelpers(t *testing.T) {
+	called := false
+	result.OK(1).Inspect(func(int) { called = true })
+	assert.True(t, called)
+
+	seen := 0
+	result.OK(1).IfOK(func(v int) { seen = v }).IfErr(func(error) { t.Fatal("unexpected") })
+	assert.Equal(t, 1, seen)
+
+	result.Fail[int](errors.New("x")).InspectErr(func(error) { called = true })
+}
+
+func TestResultCallIfOK(t *testing.T) {
+	ok := result.OK(1).CallIfOK(func(int) error { return nil })
+	assert.True(t, ok.IsOK())
+
+	fail := result.OK(1).CallIfOK(func(int) error { return errors.New("call") })
+	assert.True(t, fail.IsErr())
+
+	unchanged := result.Fail[int](errors.New("base")).CallIfOK(func(int) error {
+		t.Fatal("should not run")
+		return nil
+	})
+	assert.True(t, unchanged.IsErr())
+}
+
+func TestResultStringAndWithErr(t *testing.T) {
+	assert.Equal(t, "OK(7)", result.OK(7).String())
+	assert.Contains(t, result.Fail[int](errors.New("bad")).String(), "Error")
+
+	withTag := result.OK(1).WithErr(errors.New("tagged"), errors.Tags{"k": "v"})
+	assert.True(t, withTag.IsErr())
+
+	kept := result.OK(1).WithErr(nil)
+	assert.True(t, kept.IsOK())
+}
+
+func TestResultExpectAndMust(t *testing.T) {
+	assert.Equal(t, 3, result.OK(3).Expect("boom"))
+
+	defer recovery.Testing(t)
+	assert.Panics(t, func() {
+		_ = result.Fail[int](errors.New("x")).Expect("custom %s", "msg")
+	})
+	assert.Panics(t, func() {
+		result.Fail[int](errors.New("x")).Must()
+	})
+}
+
+func TestResultUnwrapOrThrow(t *testing.T) {
+	var r result.Result[int]
+	val := result.OK(12).UnwrapOrThrow(&r)
+	assert.Equal(t, 12, val)
+	assert.True(t, r.IsOK())
+
+	val = result.Fail[int](errors.New("throw")).UnwrapOrThrow(&r)
+	assert.Equal(t, 0, val)
+	assert.True(t, r.IsErr())
+}


### PR DESCRIPTION
## Summary

- Fix `Error.MarshalJSON` to emit valid JSON (`null` on success, enriched error JSON on failure)
- Add `FlatMap` / `FlatMapTo` aliases and clarify `Fail(nil)` panics as a programming mistake
- Make `Future.Await` prefer completed work when context is cancelled or timed out
- Replace unsafe `setError` reflection with typed `ErrSetter.applyErr` propagation
- Make `resultchecker` registration concurrent-safe and expand regression tests/docs (EN/ZH)

## Test plan

- [x] `go test ./result/... -race`
- [x] `go test ./env/... ./component/cloudevent/... ./config/...`
- [x] `go vet ./result/...`


Made with [Cursor](https://cursor.com)